### PR TITLE
[Add] 기술 선택없이 상세 지도 강조 (#30)

### DIFF
--- a/ingest-be/src/main/java/com/be/ingestbe/service/JobpostingService.java
+++ b/ingest-be/src/main/java/com/be/ingestbe/service/JobpostingService.java
@@ -57,6 +57,7 @@ public class JobpostingService {
                 .collect(Collectors.groupingBy(String::toString,Collectors.counting()));
     }
     private Boolean checkSkillInSkills(String skill,String targetSkill){
+        if(targetSkill==null || targetSkill.equals("")) return true;
         String[] posSkills = skill.split(",");
         for(String postSkill : posSkills) {
             if(postSkill.equals(targetSkill)){


### PR DESCRIPTION
기술을 선택하고 나서만 상세 지도를 강조하였지만 지역 버튼을 누르고도 상세 지도의 강조 지역을 볼 수 있도록 수정하였습니다.